### PR TITLE
Run dump_html on pre build on platformio

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -6,6 +6,7 @@ monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 framework = espidf
 platform = espressif32@5.4.0
+extra_scripts = pre:platformio_pre.py
 
 [env:esp32dev]
 board = esp32dev

--- a/platformio_pre.py
+++ b/platformio_pre.py
@@ -1,0 +1,7 @@
+from scripts.dump_html import dump
+
+dump(
+    file_from="./main/packet_forwarder/webpage.html",
+    file_to="./main/packet_forwarder/webpage.h",
+    var_name="webpage_str",
+)

--- a/scripts/dump_html.py
+++ b/scripts/dump_html.py
@@ -10,9 +10,9 @@ import sys
 
 
 def dump(
-    file_from: str = sys.argv[1],
+    file_from: str,
+    var_name: str,
     file_to: str | None = None,
-    var_name: str = sys.argv[2],
 ):
     """
     Reads a file and dumps it to bytes frame. Can write to STDOUT
@@ -45,4 +45,7 @@ def dump(
 
 
 if __name__ == "__main__":
-    dump()
+    dump(
+        file_from=sys.argv[1],
+        var_name=sys.argv[2],
+    )

--- a/scripts/dump_html.py
+++ b/scripts/dump_html.py
@@ -8,16 +8,41 @@
 import os
 import sys
 
-with open(sys.argv[1]) as f:
-    chars = f.read()
 
-print("// dump from file: %s" %os.path.basename(sys.argv[1]))
+def dump(
+    file_from: str = sys.argv[1],
+    file_to: str | None = None,
+    var_name: str = sys.argv[2],
+):
+    """
+    Reads a file and dumps it to bytes frame. Can write to STDOUT
+    or to a `file_to`.
 
-print("static const char %s[] = {\n   " %sys.argv[2], end=''),
-for (i, x) in enumerate(chars, 1):
-    print(" 0x%02X," %ord(x), end=''),
-    if i % 16 == 0:
-        print('\n   ', end='')
+    Args:
+        file_from: Filename to read from
+        file_to: None (STDOUT) or file to write
+        var_name: The variable name to associate with the bytes frame
+    """
+    result = (
+        f"// dump from file {os.path.basename(file_from)}\n"
+        f"static const char {var_name}[] = {{\n    "
+    )
 
-print(' 0x00')  # add a '\0' to the end as string terminator
-print('};')
+    with open(file_from) as f:
+        chars = f.read()
+
+    for i, x in enumerate(chars, 1):
+        result += f" 0x{ord(x):02X},"
+        if i % 16 == 0:
+            result += "\n    "
+    result += " 0x00\n};"
+
+    if file_to is None:
+        print(result)
+    else:
+        with open(file_to, "w") as f:
+            f.writelines(result)
+
+
+if __name__ == "__main__":
+    dump()


### PR DESCRIPTION
`webpage.h` was removed on refactor to generate it from the `dump_html.py` script. This script is only run when not building from PlatformIO, so I refactored the script to be able to call it also from the pre-run stage in PlatformIO. Keeps original behavior.

Related issues: #11 