### PR TITLE
fix: allow redefining of SX1302_SPI_HOST

### DIFF
--- a/main/libloragw/loragw_spi.h
+++ b/main/libloragw/loragw_spi.h
@@ -30,7 +30,9 @@ License: Revised BSD License, see LICENSE.TXT file include in the project
 #define LGW_BURST_CHUNK     1024
 
 #define SPI_SPEED           2000000
+#ifndef SX1302_SPI_HOST
 #define SX1302_SPI_HOST     HSPI_HOST
+#endif
 
 
 /**


### PR DESCRIPTION
this was problably overlooked during migration to new hal