### PR TITLE
Check if GPIO pins are set to something, otherwise ignore them

### DIFF
--- a/main/libloragw/loragw_gpio.c
+++ b/main/libloragw/loragw_gpio.c
@@ -25,9 +25,10 @@ void lgw_reset(void)
     gpio_conf.pull_down_en = 0;
     gpio_conf.pull_up_en = 0;
     gpio_config(&gpio_conf);
-
-    gpio_set_level(SX1302_POWER_EN_PIN, 1);
-    wait_ms(100);
+    if (SX1302_POWER_EN_PIN != GPIO_NUM_NC) {
+      gpio_set_level(SX1302_POWER_EN_PIN, 1);
+      wait_ms(100);
+    }
     gpio_set_level(SX1302_RESET_PIN, 1);
     wait_ms(100);
     gpio_set_level(SX1302_RESET_PIN, 0);

--- a/main/packet_forwarder/lora_pkt_fwd.c
+++ b/main/packet_forwarder/lora_pkt_fwd.c
@@ -4262,10 +4262,10 @@ void app_main(void)
 
     read_config_from_nvs();
 
-    if(gpio_get_level(USER_BUTTON_1) == BUTTON_PRESSED){
+    if(gpio_get_level(USER_BUTTON_1) == BUTTON_PRESSED && USER_BUTTON_1 != GPIO_NUM_NC){
         printf("User button 1 is PRESSED, go to soft AP mode\n");
         soft_ap_mode = true;
-    } else if(gpio_get_level(USER_BUTTON_2) == BUTTON_PRESSED){
+    } else if(gpio_get_level(USER_BUTTON_2) == BUTTON_PRESSED && USER_BUTTON_2 != GPIO_NUM_NC){
         printf("User button 2 is PRESSED, go to station mode\n");
         soft_ap_mode = false;
     } else if(config[WIFI_MODE].val == NULL){


### PR DESCRIPTION
With the code as written a gateway built without buttons and without POWER_EN connected due to use of minipcie module always starts in Soft AP mode because it thinks Button 1 is pressed, and tries to power up the gateway with POWER_EN.