### PR TITLE
allow working without temp sensor

### DIFF
--- a/main/libloragw/loragw_hal.c
+++ b/main/libloragw/loragw_hal.c
@@ -1226,7 +1226,6 @@ int lgw_receive(uint8_t max_pkt, struct lgw_pkt_rx_s *pkt_data) {
     res = lgw_get_temperature(&current_temperature);
     if (res != LGW_I2C_SUCCESS) {
         printf("ERROR: failed to get current temperature\n");
-        return LGW_HAL_ERROR;
     }
 
     /* Iterate on the RX buffer to get parsed packets */


### PR DESCRIPTION
Some modules (e.g. RAK2287) don't have temp sensors.
This patch removes exit on failed temp read and allows working without it.